### PR TITLE
Keep data frame index in reset_mask

### DIFF
--- a/dfgui/dfgui.py
+++ b/dfgui/dfgui.py
@@ -74,7 +74,7 @@ class ListCtrlDataFrame(wx.ListCtrl):
 
     def _reset_mask(self):
         #self.mask = [True] * self.df_orig.shape[0]
-        self.mask = pd.Series([True] * self.df_orig.shape[0])
+        self.mask = pd.Series([True] * self.df_orig.shape[0], index=self.df_orig.index)
 
     def _update_columns(self, columns):
         self.ClearAll()


### PR DESCRIPTION
When the source data frame is filtered, the index can be different to a range. This fixes an error happening in get_filtered_df.